### PR TITLE
migrate to voyage embedder and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ source ~/.venvs/aienv/bin/activate
 ### 2. Install libraries
 
 ```shell
-pip install -r cookbook/llm_os/requirements.txt
+pip install -r requirements.txt
 ```
 
 ### 3. Export credentials
@@ -36,6 +36,12 @@ export ANTHROPIC_API_KEY=***
 export EXA_API_KEY=xxx
 ```
 
+- To use VoyageAI for embeddings, export your VOYAGE_API_KEY (get it from [here](https://dash.voyageai.com/api-keys))
+
+```shell
+export VOYAGE_API_KEY=xxx
+```
+
 ### 4. Run PgVector
 
 We use PgVector to provide long-term memory and knowledge to the Clause OS.
@@ -44,7 +50,7 @@ Please install [docker desktop](https://docs.docker.com/desktop/install/mac-inst
 - Run using a helper script
 
 ```shell
-./cookbook/run_pgvector.sh
+./run_pgvector.sh
 ```
 
 - OR run using the docker run command
@@ -61,6 +67,8 @@ docker run -d \
   phidata/pgvector:16
 ```
 
+ - On Windows
+
 ```powershell
 docker run -d `
   -e POSTGRES_DB=ai `
@@ -76,7 +84,7 @@ docker run -d `
 ### 5. Run the Claude OS App
 
 ```shell
-streamlit run cookbook/llm_os/app.py
+streamlit run app.py
 ```
 
 - Open [localhost:8501](http://localhost:8501) to view Claude OS.

--- a/assistant.py
+++ b/assistant.py
@@ -15,6 +15,7 @@ from phi.tools.file import FileTools
 from phi.llm.anthropic import Claude
 from phi.knowledge import AssistantKnowledge
 from phi.embedder.openai import OpenAIEmbedder
+from phi.embedder.voyageai import VoyageAIEmbedder
 from phi.assistant.duckdb import DuckDbAssistant
 from phi.assistant.python import PythonAssistant
 from phi.storage.assistant.postgres import PgAssistantStorage
@@ -262,7 +263,7 @@ def get_llm_os(
             vector_db=PgVector2(
                 db_url=db_url,
                 collection="llm_os_documents",
-                embedder=OpenAIEmbedder(model="text-embedding-3-small", dimensions=1536),
+                embedder=VoyageAIEmbedder(model="voyage-large-2", dimensions=1536),
             ),
             # 3 references are added to the prompt when searching the knowledge base
             num_documents=3,

--- a/assistant.py
+++ b/assistant.py
@@ -14,7 +14,6 @@ from phi.tools.yfinance import YFinanceTools
 from phi.tools.file import FileTools
 from phi.llm.anthropic import Claude
 from phi.knowledge import AssistantKnowledge
-from phi.embedder.openai import OpenAIEmbedder
 from phi.embedder.voyageai import VoyageAIEmbedder
 from phi.assistant.duckdb import DuckDbAssistant
 from phi.assistant.python import PythonAssistant

--- a/requirements.txt
+++ b/requirements.txt
@@ -254,3 +254,4 @@ webencodings==0.5.1
     # via html5lib
 yfinance==0.2.38
     # via -r cookbook/llm_os/requirements.in
+voyageai==0.2.3

--- a/run_pgvector.sh
+++ b/run_pgvector.sh
@@ -1,0 +1,9 @@
+docker run -d \
+  -e POSTGRES_DB=ai \
+  -e POSTGRES_USER=ai \
+  -e POSTGRES_PASSWORD=ai \
+  -e PGDATA=/var/lib/postgresql/data/pgdata \
+  -v pgvolume:/var/lib/postgresql/data \
+  -p 5532:5432 \
+  --name pgvector \
+  phidata/pgvector:16


### PR DESCRIPTION
- migrate to use voyageai embedder as it is recommended by claude. (https://docs.anthropic.com/en/docs/build-with-claude/embeddings)
- using voyage-large-2 model with 1536 dimensions.
- new run_pgvector.sh script
- improve readme